### PR TITLE
feat(security): Enhance session security with HttpOnly and Secure fla…

### DIFF
--- a/src/goapp/infrastructure/session/session.go
+++ b/src/goapp/infrastructure/session/session.go
@@ -75,6 +75,8 @@ func (s *sessionManager) Save(maxAge int) error {
 	}
 
 	session.Options.MaxAge = maxAge
+	session.Options.HttpOnly = true
+	session.Options.Secure = true
 
 	return session.Save(s.r, *s.w)
 }

--- a/src/goapp/router/mux-router.go
+++ b/src/goapp/router/mux-router.go
@@ -64,7 +64,10 @@ func (r *muxRouter) SERVE() {
 	}
 
 	secureMiddleware := secure.New(secureOptions)
-	muxDispatcher.Use(secureMiddleware.Handler)
+	muxDispatcher.Use(
+		secureMiddleware.Handler,
+		commonHeadersMiddleware,
+	)
 	http.Handle("/", muxDispatcher)
 
 	muxDispatcher.NotFoundHandler = http.HandlerFunc(r.m.Chain(r.Controller.Fallback.NotFound, r.m.AzureAuth()))
@@ -72,4 +75,15 @@ func (r *muxRouter) SERVE() {
 
 	fmt.Printf("Mux HTTP server running on port %v", r.Port)
 	http.ListenAndServe(fmt.Sprintf(":%v", r.Port), muxDispatcher)
+}
+
+// commonHeadersMiddleware is the middleware function to set common headers
+func commonHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Set common headers for all requests
+		w.Header().Set("Cache-Control", "no-store")
+
+		// Call the next handler in the chain
+		next.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
This pull request enhances the security and consistency of HTTP responses by updating session cookie settings and introducing a middleware to set common response headers. The most important changes are grouped below:

**Security Improvements:**

* Set `HttpOnly` and `Secure` flags on session cookies in `session.go` to prevent client-side scripts from accessing cookies and to ensure cookies are only sent over HTTPS.

**HTTP Response Header Management:**

* Added a new `commonHeadersMiddleware` in `mux-router.go` to set the `Cache-Control: no-store` header on all responses, improving cache control and privacy.
* Updated the router setup in `mux-router.go` to apply both the security middleware and the new common headers middleware to all requests.