### PR TITLE
1347 fix compliance issues

### DIFF
--- a/src/goapp/infrastructure/session/session.go
+++ b/src/goapp/infrastructure/session/session.go
@@ -77,6 +77,7 @@ func (s *sessionManager) Save(maxAge int) error {
 	session.Options.MaxAge = maxAge
 	session.Options.HttpOnly = true
 	session.Options.Secure = true
+	session.Options.SameSite = http.SameSiteStrictMode
 
 	return session.Save(s.r, *s.w)
 }

--- a/src/goapp/infrastructure/session/session.go
+++ b/src/goapp/infrastructure/session/session.go
@@ -77,7 +77,7 @@ func (s *sessionManager) Save(maxAge int) error {
 	session.Options.MaxAge = maxAge
 	session.Options.HttpOnly = true
 	session.Options.Secure = true
-	session.Options.SameSite = http.SameSiteStrictMode
+	session.Options.SameSite = http.SameSiteLaxMode
 
 	return session.Save(s.r, *s.w)
 }


### PR DESCRIPTION
This pull request introduces a small security improvement to the session management logic by setting the `SameSite` attribute for session cookies. This helps mitigate certain types of cross-site request forgery (CSRF) attacks.