### PR TITLE
fix(middleware): Enhance AzureAuth cookie settings for improved security

### DIFF
--- a/src/goapp/middleware/middleware.go
+++ b/src/goapp/middleware/middleware.go
@@ -46,8 +46,13 @@ func (m *middleware) AzureAuth() MiddlewareFunc {
 			isAuth, tokenExpired, err := m.Service.Authenticator.IsAuthenticated(r)
 			if err != nil {
 				c := http.Cookie{
-					Name:   "auth-session",
-					MaxAge: -1}
+					Name:     "auth-session",
+					MaxAge:   -1,
+					Path:     "/",
+					Secure:   true,
+					HttpOnly: true,
+					SameSite: http.SameSiteLaxMode,
+				}
 				http.SetCookie(w, &c)
 				http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 				return
@@ -58,8 +63,13 @@ func (m *middleware) AzureAuth() MiddlewareFunc {
 					err := m.Service.Authenticator.RefreshToken(&w, r)
 					if err != nil {
 						c := http.Cookie{
-							Name:   "auth-session",
-							MaxAge: -1}
+							Name:     "auth-session",
+							MaxAge:   -1,
+							Path:     "/",
+							Secure:   true,
+							HttpOnly: true,
+							SameSite: http.SameSiteLaxMode,
+						}
 						http.SetCookie(w, &c)
 						http.Redirect(w, r, "/logout", http.StatusTemporaryRedirect)
 						return


### PR DESCRIPTION
This pull request enhances the security and consistency of the `auth-session` cookie handling in the authentication middleware. The main change is the addition of several cookie attributes to ensure secure cookie usage and proper session invalidation.

**Security and cookie handling improvements:**

* Added `Path`, `Secure`, `HttpOnly`, and `SameSite` attributes to the `auth-session` cookie when invalidating it, ensuring it is properly scoped, only sent over HTTPS, inaccessible to JavaScript, and protected against CSRF attacks. (`src/goapp/middleware/middleware.go`, [[1]](diffhunk://#diff-0795c412ed1659a485972b45fe0871015986292cdae2af5852155460b77ef57cL50-R55) [[2]](diffhunk://#diff-0795c412ed1659a485972b45fe0871015986292cdae2af5852155460b77ef57cL62-R72)